### PR TITLE
Updated expected Observer Support/Health values

### DIFF
--- a/check_homeassistant.sh
+++ b/check_homeassistant.sh
@@ -4,7 +4,7 @@
 # Description: Nagios plugin to check Home Assistant via Observer page
 # Website: https://github.com/wimvr/nagios-check_homeassistant
 
-VERSION="0.1"
+VERSION="0.2"
 
 HOST=''
 PORT=4357
@@ -14,6 +14,10 @@ STATUS_OK=0
 STATUS_WARNING=1
 STATUS_CRITICAL=2
 STATUS_UNKNOWN=3
+
+function prereq() {
+[[ ! -x $(command -v "$1") ]] && { echo "$1 is required"; exit $STATUS_UNKNOWN; }
+}
 
 function usage {
 	echo "Usage:"
@@ -39,7 +43,7 @@ while getopts "H:p:t:hV" args; do
 		p) PORT=$OPTARG ;;
 		t) TIMEOUT=$OPTARG ;;
 		V)
-			echo "`basename $0` version ${VERSION}"
+			echo "$(basename "$0") version ${VERSION}"
 			exit $STATUS_UNKNOWN
 			;;
 		*)
@@ -69,14 +73,16 @@ if ! [[ $TIMEOUT =~ $re ]]; then
 	exit $STATUS_UNKNOWN
 fi
 
-PAGE=`wget -O - --quiet --timeout=$TIMEOUT http://${HOST}:${PORT}/`
+prereq xmllint
+
+PAGE=$(wget -O - --quiet --timeout=$TIMEOUT http://${HOST}:${PORT}/)
 if [ $? -ne 0 ]; then
 	echo "CRITICAL: No response received while requesting status"
 	exit $STATUS_CRITICAL
 fi
 
-if [ "`echo $PAGE | xmllint --html --xpath '//table/tr[1]/td[1]/text()' -`" == " Supervisor: " ]; then
-	if [ "`echo $PAGE | xmllint --html --xpath '//table/tr[1]/td[2]/text()' -`" != " Connected " ]; then
+if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[1]/td[1]/text()' -)" == " Supervisor: " ]; then
+	if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[1]/td[2]/text()' -)" != " Connected " ]; then
 		echo "CRITICAL: supervisor not connected"
 		exit $STATUS_CRITICAL
 	fi
@@ -85,18 +91,18 @@ else
 	exit $STATUS_UNKNOWN
 fi
 
-if [ "`echo $PAGE | xmllint --html --xpath '//table/tr[2]/td[1]/text()' -`" == " Supported: " ]; then
-	if [ "`echo $PAGE | xmllint --html --xpath '//table/tr[2]/td[2]/text()' -`" != " Supported " ]; then
+if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[2]/td[1]/text()' -)" == " Support: " ]; then
+	if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[2]/td[2]/text()' -)" != " Supported " ]; then
 		echo "CRITICAL: not supported"
-		exit $STATUS_CRITICAL
+		exit $STATUS_WARNING
 	fi
 else
 	echo "UNKNOWN: unrecognised observer page"
 	exit $STATUS_UNKNOWN
 fi
 
-if [ "`echo $PAGE | xmllint --html --xpath '//table/tr[3]/td[1]/text()' -`" == " Healthy: " ]; then
-	if [ "`echo $PAGE | xmllint --html --xpath '//table/tr[3]/td[2]/text()' -`" != " Healthy " ]; then
+if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[3]/td[1]/text()' -)" == " Health: " ]; then
+	if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[3]/td[2]/text()' -)" != " Healthy " ]; then
 		echo "CRITICAL: not healthy"
 		exit $STATUS_CRITICAL
 	fi
@@ -107,4 +113,3 @@ fi
 
 echo "OK: observer reports Home Assistant up and running"
 exit $STATUS_OK
-

--- a/check_homeassistant.sh
+++ b/check_homeassistant.sh
@@ -83,33 +83,33 @@ fi
 
 if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[1]/td[1]/text()' -)" == " Supervisor: " ]; then
 	if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[1]/td[2]/text()' -)" != " Connected " ]; then
-		echo "CRITICAL: supervisor not connected"
+		echo "CRITICAL: Supervisor not connected"
 		exit $STATUS_CRITICAL
 	fi
 else
-	echo "UNKNOWN: unrecognised observer page"
-	exit $STATUS_UNKNOWN
-fi
-
-if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[2]/td[1]/text()' -)" == " Support: " ]; then
-	if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[2]/td[2]/text()' -)" != " Supported " ]; then
-		echo "CRITICAL: not supported"
-		exit $STATUS_WARNING
-	fi
-else
-	echo "UNKNOWN: unrecognised observer page"
+	echo "UNKNOWN: Unrecognised observer page"
 	exit $STATUS_UNKNOWN
 fi
 
 if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[3]/td[1]/text()' -)" == " Health: " ]; then
 	if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[3]/td[2]/text()' -)" != " Healthy " ]; then
-		echo "CRITICAL: not healthy"
+		echo "CRITICAL: Home Assistant not healthy"
 		exit $STATUS_CRITICAL
 	fi
 else
-	echo "UNKNOWN: unrecognised observer page"
+	echo "UNKNOWN: Unrecognised observer page"
 	exit $STATUS_UNKNOWN
 fi
 
-echo "OK: observer reports Home Assistant up and running"
+if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[2]/td[1]/text()' -)" == " Support: " ]; then
+	if [ "$(echo $PAGE | xmllint --html --xpath '//table/tr[2]/td[2]/text()' -)" != " Supported " ]; then
+		echo "WARNING: Home Assistant is healthy but not supported"
+		exit $STATUS_WARNING
+	fi
+else
+	echo "UNKNOWN: Unrecognised observer page"
+	exit $STATUS_UNKNOWN
+fi
+
+echo "OK: Observer reports Home Assistant up and running"
 exit $STATUS_OK


### PR DESCRIPTION
This afternoon after I rebooted my server I noticed that the checks started returning `UNKNOWN` because the Observer page changed `Supported:` to `Support:` and `Healthy:` to `Health:`. This change actually happened quite a while ago: https://github.com/home-assistant/plugin-observer/pull/166/
While I was there I made some Shellcheck code changes, added an `xmllint` prerequisite check (might help a few people out) and made the `Unsupported` output `WARNING`, reasoning that this might be a problem but Home Assistant should be working fine.

I'd like to extend this check later on after diving more into the Observer plugin code :-) 